### PR TITLE
Setup TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+
+language: java
+
+jdk:
+  - oraclejdk7
+  - oraclejdk8
+  - openjdk7
+
+matrix:
+    allow_failures:
+        - jdk: oraclejdk8
+
+before_install:  
+ - "export JAVA_OPTS=-Xmx1500m"
+ - "echo JAVA_OPTS=$JAVA_OPTS"
+ - "export MAVEN_OPTS=-Xmx1500m"
+ - "echo MAVEN_OPTS=$MAVEN_OPTS"
+ - "export _JAVA_OPTIONS=-Xmx1500m"
+ - "echo _JAVA_OPTIONS=$_JAVA_OPTIONS"
+
+script:
+ - mvn clean install
+ - cd contrib && mvn clean install


### PR DESCRIPTION
Hey @anjackson, here is the TravisCI setup. If you're cool with this, and merge it, it should automatically show up in https://github.com/internetarchive/heritrix3/pull/154.

I combined your [`.travis.yml`](https://github.com/ukwa/heritrix3/blob/travis/.travis.yml) and my [`.travis.yml`](https://github.com/ruebot/heritrix3/blob/travis/.travis.yml), and added the `allow failures` section in the build matrix. It tests against oraclejdk7, openjdk7, oraclejdk8, and allows failures on the oraclejdk8 build. You can see it in action [here](https://travis-ci.org/ruebot/heritrix3/builds/123025655).

![screenshot from 2016-04-14 07-37-39](https://cloud.githubusercontent.com/assets/218561/14526787/cc272c92-0213-11e6-99d7-93b5d003b359.png)
